### PR TITLE
Option to include the class name in labels of function nodes that are methods

### DIFF
--- a/alpaca/serialization/identifiers.py
+++ b/alpaca/serialization/identifiers.py
@@ -100,5 +100,4 @@ def activity_info(identifier):
         "type": NSS_FUNCTION,
         "execution_id": exec_id
     }
-    data["label"] = data["Python_name"].split(".")[-1]
     return data

--- a/alpaca/test/res/class_method.ttl
+++ b/alpaca/test/res/class_method.ttl
@@ -1,0 +1,40 @@
+@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:fz-juelich.de:alpaca:object:Python:test.OutputObject:54321> a alpaca:DataObjectEntity ;
+    prov:wasDerivedFrom <urn:fz-juelich.de:alpaca:object:Python:test.InputObject:12345> ,
+        <urn:fz-juelich.de:alpaca:object:Python:test.ObjectWithMethod:232323> ;
+    prov:wasAttributedTo <urn:fz-juelich.de:alpaca:script:Python:script.py:111111#999999> ;
+    prov:wasGeneratedBy <urn:fz-juelich.de:alpaca:function_execution:Python:111111:999999:test.ObjectWithMethod.process#12345> ;
+    alpaca:hashSource "joblib_SHA1" .
+
+<urn:fz-juelich.de:alpaca:object:Python:test.InputObject:12345> a alpaca:DataObjectEntity ;
+    prov:wasAttributedTo <urn:fz-juelich.de:alpaca:script:Python:script.py:111111#999999> ;
+    alpaca:hashSource "joblib_SHA1" .
+
+<urn:fz-juelich.de:alpaca:object:Python:test.ObjectWithMethod:232323> a alpaca:DataObjectEntity ;
+    prov:wasAttributedTo <urn:fz-juelich.de:alpaca:script:Python:script.py:111111#999999> ;
+    alpaca:hashSource "joblib_SHA1" .
+
+
+<urn:fz-juelich.de:alpaca:function_execution:Python:111111:999999:test.ObjectWithMethod.process#12345> a alpaca:FunctionExecution ;
+    prov:startedAtTime "2022-05-02T12:34:56.123456"^^xsd:dateTime ;
+    prov:endedAtTime "2022-05-02T12:35:56.123456"^^xsd:dateTime ;
+    prov:used <urn:fz-juelich.de:alpaca:object:Python:test.ObjectWithMethod:232323> ,
+        <urn:fz-juelich.de:alpaca:object:Python:test.InputObject:12345> ;
+    prov:wasAssociatedWith <urn:fz-juelich.de:alpaca:script:Python:script.py:111111#999999> ;
+    alpaca:codeStatement "res = obj.process(INPUT, 4)" ;
+    alpaca:executionOrder 1 ;
+    alpaca:usedFunction <urn:fz-juelich.de:alpaca:function:Python:test.ObjectWithMethod.process> ;
+    alpaca:hasParameter [ a alpaca:NameValuePair ;
+        alpaca:pairName "param1" ;
+        alpaca:pairValue 4 ] .
+
+<urn:fz-juelich.de:alpaca:function:Python:test.ObjectWithMethod.process> a alpaca:Function ;
+    alpaca:functionName "ObjectWithMethod.process" ;
+    alpaca:implementedIn "test" ;
+    alpaca:functionVersion "" .
+
+<urn:fz-juelich.de:alpaca:script:Python:script.py:111111#999999> a alpaca:ScriptAgent ;
+    alpaca:scriptPath "/script.py" .

--- a/alpaca/test/test_graph.py
+++ b/alpaca/test/test_graph.py
@@ -215,6 +215,28 @@ class ProvenanceGraphTestCase(unittest.TestCase):
         self.assertEqual(node_attrs["name"], "Spiketrain#1")
         self.assertEqual(node_attrs["sua"], "false")
 
+    def test_use_class_in_method_name(self):
+        input_file = self.ttl_path / "class_method.ttl"
+
+        graph = ProvenanceGraph(input_file, attributes=None,
+                                annotations=None,
+                                use_class_in_method_name=True)
+        node_attrs = graph.graph.nodes[
+            "urn:fz-juelich.de:alpaca:function_execution:Python:111111:999999:test.ObjectWithMethod.process#12345"]
+
+        self.assertEqual(node_attrs["label"], "ObjectWithMethod.process")
+
+    def test_no_use_class_in_method_name(self):
+        input_file = self.ttl_path / "class_method.ttl"
+
+        graph = ProvenanceGraph(input_file, attributes=None,
+                                annotations=None,
+                                use_class_in_method_name=False)
+        node_attrs = graph.graph.nodes[
+            "urn:fz-juelich.de:alpaca:function_execution:Python:111111:999999:test.ObjectWithMethod.process#12345"]
+
+        self.assertEqual(node_attrs["label"], "process")
+
     def test_no_strip_namespace(self):
         input_file = self.ttl_path / "metadata.ttl"
 

--- a/alpaca/test/test_serialization.py
+++ b/alpaca/test/test_serialization.py
@@ -159,6 +159,40 @@ class AlpacaProvSerializationTestCase(unittest.TestCase):
         self.assertTrue(assert_rdf_graphs_equal(alpaca_prov.graph,
                                                 expected_graph))
 
+    def test_class_method_serialization(self):
+        obj_info = DataObject(
+            hash="232323",
+            hash_method="joblib_SHA1",
+            type="test.ObjectWithMethod",
+            id=232323,
+            details={})
+
+        function_execution = FunctionExecution(
+            function=FunctionInfo('ObjectWithMethod.process',
+                                  'test', ''),
+            input={'self': obj_info, 'array': INPUT},
+            params={'param1': 4},
+            output={0: OUTPUT}, call_ast=None,
+            arg_map=['self', 'array', 'param1'], kwarg_map=[],
+            return_targets=[],
+            time_stamp_start=TIMESTAMP_START, time_stamp_end=TIMESTAMP_END,
+            execution_id="12345", order=1,
+            code_statement="res = obj.process(INPUT, 4)")
+
+        # Load expected RDF graph
+        expected_graph_file = self.ttl_path / "class_method.ttl"
+        expected_graph = rdflib.Graph()
+        expected_graph.parse(expected_graph_file, format='turtle')
+
+        # Serialize the history using AlpacaProv document
+        alpaca_prov = AlpacaProvDocument()
+        alpaca_prov.add_history(SCRIPT_INFO, SCRIPT_SESSION_ID,
+                                history=[function_execution])
+
+        # Check if graphs are equal
+        self.assertTrue(assert_rdf_graphs_equal(alpaca_prov.graph,
+                                                expected_graph))
+
     def test_input_multiple_serialization(self):
         function_execution = FunctionExecution(
             function=TEST_FUNCTION,


### PR DESCRIPTION
In the visualization graph, when a tracked function is a method inside a class, only the method name is displayed, which can result in ambiguous labels, especially for methods such as `__init__` and `__call__`. 

This PR adds an option in the `ProvenanceGraph` class to have labels with the class name as a prefix, i.e., `ClassName.method` instead of just `method`.

Corresponding unit tests were added.