### PR TITLE
Added setting to define the authority in the identifiers

### DIFF
--- a/alpaca/serialization/identifiers.py
+++ b/alpaca/serialization/identifiers.py
@@ -4,14 +4,11 @@ Alpaca.
 """
 
 import pathlib
+import re
 
 # Values that are used to compose the URNs
 # URNs take the general form "urn:NID:NSS", followed by optional components
 # according to RFC 8141.
-
-AUTHORITY = "fz-juelich.de"
-
-NID_ALPACA = f"{AUTHORITY}:alpaca"
 
 NSS_FUNCTION = "function"             # Functions executed
 NSS_FILE = "file"                     # Files accessed
@@ -19,22 +16,24 @@ NSS_DATA = "object"                   # Data objects (input/outputs/containers)
 NSS_SCRIPT = "script"                 # The execution script
 NSS_EXECUTION = "function_execution"  # Execution of a function
 
-BASE_URN = f"urn:{NID_ALPACA}"
+
+def get_base_urn(authority):
+    return f"urn:{authority}:alpaca"
 
 
 # <urn:fz-juelich.de:alpaca:object:Python:neo.core.AnalogSignal:423423432432423432432>
-def data_object_identifier(object_info):
+def data_object_identifier(object_info, authority):
     object_hash = object_info.hash
     type_string = object_info.type
-    urn = f"{BASE_URN}:{NSS_DATA}:Python:{type_string}:{object_hash}"
+    urn = f"{get_base_urn(authority)}:{NSS_DATA}:Python:{type_string}:{object_hash}"
     return urn
 
 
 # <urn:fz-juelich.de:alpaca:file:sha256:234234324324324324234324>
-def file_identifier(file_info):
+def file_identifier(file_info, authority):
     hash_type = file_info.hash_type
     file_hash = file_info.hash
-    urn = f"{BASE_URN}:{NSS_FILE}:{hash_type}:{file_hash}"
+    urn = f"{get_base_urn(authority)}:{NSS_FILE}:{hash_type}:{file_hash}"
     return urn
 
 
@@ -47,24 +46,25 @@ def _get_function_name(function_info):
 
 
 # <urn:fz-juelich.de:alpaca:function:Python:elephant.spectral.welch_psd>
-def function_identifier(function_info):
+def function_identifier(function_info, authority):
     function_name = _get_function_name(function_info)
-    urn = f"{BASE_URN}:{NSS_FUNCTION}:Python:{function_name}"
+    urn = f"{get_base_urn(authority)}:{NSS_FUNCTION}:Python:{function_name}"
     return urn
 
 
 # <urn:fz-juelich.de:alpaca:script:Python:run_psd.py:f32432j34k24#4567-4567-dflsd4-dfdsfs>
-def script_identifier(script_info, session_id):
+def script_identifier(script_info, session_id, authority):
     script_name = pathlib.Path(script_info.path).name
-    urn = f"{BASE_URN}:{NSS_SCRIPT}:Python:{script_name}:{script_info.hash}" \
-          f"#{session_id}"
+    urn = f"{get_base_urn(authority)}:{NSS_SCRIPT}:Python:{script_name}:" \
+          f"{script_info.hash}#{session_id}"
     return urn
 
 
-def execution_identifier(script_info, function_info, session_id, execution_id):
+def execution_identifier(script_info, function_info, session_id, execution_id,
+                         authority):
     function_name = _get_function_name(function_info)
-    urn = f"{BASE_URN}:{NSS_EXECUTION}:Python:{script_info.hash}:" \
-          f"{session_id}:{function_name}#{execution_id}"
+    urn = f"{get_base_urn(authority)}:{NSS_EXECUTION}:Python:" \
+          f"{script_info.hash}:{session_id}:{function_name}#{execution_id}"
     return urn
 
 
@@ -72,7 +72,8 @@ def execution_identifier(script_info, function_info, session_id, execution_id):
 # visualizations with NetworkX graphs.
 
 def _strip_local_part(identifier):
-    return identifier.split(f"{BASE_URN}:")[1]
+    match = re.match(r"urn:[^:]+:alpaca:(.+)", identifier)
+    return match.group(1)
 
 
 def entity_info(identifier):

--- a/alpaca/serialization/prov.py
+++ b/alpaca/serialization/prov.py
@@ -25,6 +25,7 @@ from alpaca.serialization.neo import _neo_object_metadata
 
 from alpaca.utils.files import _get_prov_file_format
 from alpaca.alpaca_types import DataObject, File, Container
+from alpaca.settings import _ALPACA_SETTINGS
 
 
 def _add_name_value_pair(graph, uri, predicate, name, value):
@@ -61,6 +62,7 @@ class AlpacaProvDocument(object):
         self.graph = Graph()
         self.graph.namespace_manager.bind('alpaca', ALPACA)
         self.graph.namespace_manager.bind('prov', PROV)
+        self._authority = _ALPACA_SETTINGS['authority']
 
         # Metadata plugins are used for packages (e.g., Neo) that require
         # special handling of metadata when adding to the PROV records.
@@ -91,7 +93,8 @@ class AlpacaProvDocument(object):
 
     def _add_ScriptAgent(self, script_info, session_id):
         # Adds a ScriptAgent record from the Alpaca PROV model
-        uri = URIRef(script_identifier(script_info, session_id))
+        uri = URIRef(script_identifier(script_info, session_id,
+                                       self._authority))
         self.graph.add((uri, RDF.type, ALPACA.ScriptAgent))
         self.graph.add((uri, ALPACA.scriptPath, Literal(script_info.path)))
         return uri
@@ -100,7 +103,7 @@ class AlpacaProvDocument(object):
 
     def _add_Function(self, function_info):
         # Adds a Function record from the Alpaca PROV model
-        uri = URIRef(function_identifier(function_info))
+        uri = URIRef(function_identifier(function_info, self._authority))
         self.graph.add((uri, RDF.type, ALPACA.Function))
         self.graph.add((uri, ALPACA.functionName,
                         Literal(function_info.name)))
@@ -115,7 +118,8 @@ class AlpacaProvDocument(object):
                                code_statement, start, end, function):
         # Adds a FunctionExecution record from the Alpaca PROV model
         uri = URIRef(execution_identifier(
-            script_info, function_info, session_id, execution_id))
+            script_info, function_info, session_id, execution_id,
+            self._authority))
         self.graph.add((uri, RDF.type, ALPACA.FunctionExecution))
         self.graph.add((uri, PROV.startedAtTime,
                         Literal(start, datatype=XSD.dateTime)))
@@ -137,7 +141,7 @@ class AlpacaProvDocument(object):
     def _add_DataObjectEntity(self, info):
         # Adds a DataObjectEntity from the Alpaca PROV model
         # If the entity already exists, skip it
-        uri = URIRef(data_object_identifier(info))
+        uri = URIRef(data_object_identifier(info, self._authority))
 
         if uri in self.graph.subjects(RDF.type, ALPACA.DataObjectEntity):
             return uri
@@ -148,7 +152,7 @@ class AlpacaProvDocument(object):
 
     def _add_FileEntity(self, info):
         # Adds a FileEntity from the Alpaca PROV model
-        uri = URIRef(file_identifier(info))
+        uri = URIRef(file_identifier(info, self._authority))
         self.graph.add((uri, RDF.type, ALPACA.FileEntity))
         self.graph.add((uri, ALPACA.filePath,
                         Literal(info.path, datatype=XSD.string)))

--- a/alpaca/settings.py
+++ b/alpaca/settings.py
@@ -35,6 +35,22 @@ Currently, the following settings can be defined:
 
         Default: []
 
+* **authority**: str
+        The string defining the authority component used in the identifiers
+        throughout Alpaca.
+
+        Data objects, files, scripts, functions, and function executions are
+        serialized to RDF using URN identifiers. The basic form of the
+        identifier string is `urn:[authority]:alpaca:[complement]`, where
+        `[complement]` is a string composed by specific information of each
+        element identified.
+
+        `[authority]` is a string that points to the institute or organisation
+        which has responsibility over the script execution, and is defined
+        by this setting.
+
+        Default: "my-authority"
+
 
 To set/read a setting, use the function :func:`alpaca_setting`.
 
@@ -44,7 +60,8 @@ To set/read a setting, use the function :func:`alpaca_setting`.
 # Global Alpaca settings dictionary
 # Should be modified only through the `alpaca_setting` function.
 
-_ALPACA_SETTINGS = {'use_builtin_hash_for_module': []}
+_ALPACA_SETTINGS = {'use_builtin_hash_for_module': [],
+                    'authority': "my-authority"}
 
 
 def alpaca_setting(name, value=None):

--- a/alpaca/test/test_graph.py
+++ b/alpaca/test/test_graph.py
@@ -6,7 +6,7 @@ import networkx as nx
 from functools import partial
 from collections import Counter
 
-from alpaca import ProvenanceGraph
+from alpaca import ProvenanceGraph, alpaca_setting
 
 
 class ProvenanceGraphTestCase(unittest.TestCase):
@@ -31,6 +31,7 @@ class ProvenanceGraphTestCase(unittest.TestCase):
                                                    suffix="tmp")
         cls.graph_comparison = partial(nx.is_isomorphic,
                                        node_match=cls._attr_comparison)
+        alpaca_setting('authority', "my-authority")
 
     def test_graph_behavior_and_serialization(self):
         input_file = self.ttl_path / "input_output.ttl"
@@ -353,6 +354,7 @@ class GraphAggregationTestCase(unittest.TestCase):
         cls.ttl_path = Path(__file__).parent / "res"
         input_file = cls.ttl_path / "parallel_graph.ttl"
         cls.graph = ProvenanceGraph(input_file, attributes=['shape', 'metadata'])
+        alpaca_setting('authority', "my-authority")
 
     def test_serialization(self):
         temp_dir = tempfile.TemporaryDirectory(dir=self.ttl_path, suffix="tmp")
@@ -466,6 +468,7 @@ class GraphAggregationTestCase(unittest.TestCase):
                         self.assertEqual(attrs[key], value)
                     else:
                         self.assertTrue(attrs[key] in value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/alpaca/test/test_serialization.py
+++ b/alpaca/test/test_serialization.py
@@ -12,7 +12,7 @@ import neo
 from alpaca.alpaca_types import (DataObject, File, FunctionInfo,
                                  FunctionExecution,
                                  Container)
-from alpaca import AlpacaProvDocument
+from alpaca import AlpacaProvDocument, alpaca_setting
 from alpaca.serialization.converters import _ensure_type
 from alpaca.serialization.neo import _neo_to_prov
 
@@ -81,6 +81,7 @@ class AlpacaProvSerializationTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ttl_path = Path(__file__).parent / "res"
+        alpaca_setting('authority', "fz-juelich.de")
 
     def test_input_output_serialization(self):
         function_execution = FunctionExecution(
@@ -324,6 +325,7 @@ class SerializationIOTestCase(unittest.TestCase):
         cls.alpaca_prov = AlpacaProvDocument()
         cls.alpaca_prov.add_history(SCRIPT_INFO, SCRIPT_SESSION_ID,
                                     history=[function_execution])
+        alpaca_setting('authority', "fz-juelich.de")
 
     def test_serialization_deserialization(self):
 
@@ -425,6 +427,10 @@ class ConvertersTestCase(unittest.TestCase):
 
 
 class MultipleMembershipSerializationTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        alpaca_setting('authority', "fz-juelich.de")
 
     def test_multiple_memberships(self):
         # test relationship `super_container.containers[0].inputs[1]`

--- a/alpaca/test/test_settings.py
+++ b/alpaca/test/test_settings.py
@@ -25,6 +25,25 @@ class AlpacaSettingsTestCase(unittest.TestCase):
         alpaca_setting(setting_name, cur_setting)
         self.assertListEqual(_ALPACA_SETTINGS[setting_name], cur_setting)
 
+    def test_authority(self):
+        setting_name = 'authority'
+
+        cur_setting = alpaca_setting(setting_name)
+        self.assertIsInstance(cur_setting, str)
+
+        new_setting = alpaca_setting(setting_name, "test-authority")
+        self.assertEqual(new_setting, "test-authority")
+        self.assertEqual(alpaca_setting(setting_name), "test-authority")
+        self.assertEqual(_ALPACA_SETTINGS[setting_name], "test-authority")
+
+        # Test wrong type
+        with self.assertRaises(ValueError):
+            alpaca_setting(setting_name, ["test wrong type"])
+
+        # Restore value
+        alpaca_setting(setting_name, cur_setting)
+        self.assertEqual(_ALPACA_SETTINGS[setting_name], cur_setting)
+
     def test_wrong_setting_name(self):
         with self.assertRaises(ValueError):
             alpaca_setting("wrong_setting")


### PR DESCRIPTION
The initial version of Alpaca had a fixed authority string in the URN identifiers. 

This PR implements a feature to use the `alpaca_setting` function to define the authority element in the provenance records. This should be set before the serialization, with the `'authority'` keyword:

```
alpaca_setting('authority', <string>)
```