### PR TITLE
Update Alpaca ontology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,10 @@ dmypy.json
 # sphinx build directory
 doc/_build
 
+# Protégé files
+/alpaca/ontology/alpaca.properties
+/alpaca/ontology/catalog-v001.xml
+
 # Output files
 /examples/*.ttl
 /examples/*.png

--- a/alpaca/ontology/alpaca.owl
+++ b/alpaca/ontology/alpaca.owl
@@ -1,42 +1,53 @@
-@prefix : <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix : <http://purl.org/alpaca#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@base <http://purl.org/alpaca#> .
 
-<https://github.com/INM-6/alpaca/ontology/alpaca.owl#> rdf:type owl:Ontology ;
-                                                        owl:imports <http://www.w3.org/ns/prov-o-20130430> ;
-                                                        rdfs:comment "An extension to PROV-O to support the serialization of provenance information captured with Alpaca as RDF triples." .
+<http://purl.org/alpaca#> rdf:type owl:Ontology ;
+                           owl:imports <http://www.w3.org/ns/prov-o-20130430> ;
+                           dcterms:creator "Cristiano Köhler (c.koehler@fz-juelich.de)" ;
+                           rdfs:comment "An extension to PROV-O to support the serialization of provenance information captured with Alpaca as RDF triples."@en ;
+                           owl:versionInfo "0.1.0" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/terms/creator
+dcterms:creator rdf:type owl:AnnotationProperty .
+
 
 #################################################################
 #    Object Properties
 #################################################################
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#hasAnnotation
+###  http://purl.org/alpaca#hasAnnotation
 :hasAnnotation rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf owl:topObjectProperty ;
                rdfs:domain :DataObjectEntity ;
                rdfs:range :NameValuePair .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#hasAttribute
+###  http://purl.org/alpaca#hasAttribute
 :hasAttribute rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf owl:topObjectProperty ;
               rdfs:domain :DataObjectEntity ;
               rdfs:range :NameValuePair .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#hasParameter
+###  http://purl.org/alpaca#hasParameter
 :hasParameter rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf owl:topObjectProperty ;
               rdfs:domain :FunctionExecution ;
               rdfs:range :NameValuePair .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#usedFunction
+###  http://purl.org/alpaca#usedFunction
 :usedFunction rdf:type owl:ObjectProperty ;
               rdfs:domain :FunctionExecution ;
               rdfs:range :Function .
@@ -46,80 +57,80 @@
 #    Data properties
 #################################################################
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#codeStatement
+###  http://purl.org/alpaca#codeStatement
 :codeStatement rdf:type owl:DatatypeProperty ;
                rdfs:domain :FunctionExecution ;
                rdfs:range xsd:string .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#containerIndex
+###  http://purl.org/alpaca#containerIndex
 :containerIndex rdf:type owl:DatatypeProperty ;
                 rdfs:domain :DataObjectEntity ;
                 rdfs:range rdfs:Literal .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#containerSlice
+###  http://purl.org/alpaca#containerSlice
 :containerSlice rdf:type owl:DatatypeProperty ;
                 rdfs:domain :DataObjectEntity ;
                 rdfs:range rdfs:Literal .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#executionOrder
+###  http://purl.org/alpaca#executionOrder
 :executionOrder rdf:type owl:DatatypeProperty ;
                 rdfs:domain :FunctionExecution ;
                 rdfs:range xsd:int .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#filePath
+###  http://purl.org/alpaca#filePath
 :filePath rdf:type owl:DatatypeProperty ;
           rdfs:domain :FileEntity ;
           rdfs:range xsd:string .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#fromAttribute
+###  http://purl.org/alpaca#fromAttribute
 :fromAttribute rdf:type owl:DatatypeProperty ;
                rdfs:domain :DataObjectEntity ;
                rdfs:range xsd:string .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#functionName
+###  http://purl.org/alpaca#functionName
 :functionName rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf owl:topDataProperty ;
               rdfs:domain :Function ;
               rdfs:range xsd:string .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#functionVersion
+###  http://purl.org/alpaca#functionVersion
 :functionVersion rdf:type owl:DatatypeProperty ;
                  rdfs:domain :Function ;
                  rdfs:range xsd:string .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#hashSource
+###  http://purl.org/alpaca#hashSource
 :hashSource rdf:type owl:DatatypeProperty ;
             rdfs:domain :DataObjectEntity ;
             rdfs:range xsd:string .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#implementedIn
+###  http://purl.org/alpaca#implementedIn
 :implementedIn rdf:type owl:DatatypeProperty ;
                rdfs:domain :Function ;
                rdfs:range xsd:string .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#pairName
+###  http://purl.org/alpaca#pairName
 :pairName rdf:type owl:DatatypeProperty ;
           rdfs:domain :NameValuePair ;
           rdfs:range xsd:string .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#pairValue
+###  http://purl.org/alpaca#pairValue
 :pairValue rdf:type owl:DatatypeProperty ;
            rdfs:domain :NameValuePair ;
            rdfs:range rdfs:Literal .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#scriptPath
+###  http://purl.org/alpaca#scriptPath
 :scriptPath rdf:type owl:DatatypeProperty ;
             rdfs:domain :ScriptAgent ;
             rdfs:range xsd:string .
@@ -129,35 +140,35 @@
 #    Classes
 #################################################################
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#DataObjectEntity
+###  http://purl.org/alpaca#DataObjectEntity
 :DataObjectEntity rdf:type owl:Class ;
                   rdfs:subClassOf prov:Entity ;
                   rdfs:comment "Represents an object that contains data." .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#FileEntity
+###  http://purl.org/alpaca#FileEntity
 :FileEntity rdf:type owl:Class ;
             rdfs:subClassOf prov:Entity ;
             rdfs:comment "Represents a file in the system." .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#Function
+###  http://purl.org/alpaca#Function
 :Function rdf:type owl:Class ;
           rdfs:comment "Represents a function object. It contains code that is executed to perform some action in the script, taking parameters and producing outputs." .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#FunctionExecution
+###  http://purl.org/alpaca#FunctionExecution
 :FunctionExecution rdf:type owl:Class ;
                    rdfs:subClassOf prov:Activity ;
                    rdfs:comment "The execution of a function with a set of inputs and parameters, that may produce one or more outputs." .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#NameValuePair
+###  http://purl.org/alpaca#NameValuePair
 :NameValuePair rdf:type owl:Class ;
                rdfs:comment "Represents information defined by a name/value pair. Name is a string and value can be any literal value." .
 
 
-###  https://github.com/INM-6/alpaca/ontology/alpaca.owl#ScriptAgent
+###  http://purl.org/alpaca#ScriptAgent
 :ScriptAgent rdf:type owl:Class ;
              rdfs:subClassOf prov:SoftwareAgent .
 

--- a/alpaca/ontology/alpaca.owl
+++ b/alpaca/ontology/alpaca.owl
@@ -30,27 +30,35 @@ dcterms:creator rdf:type owl:AnnotationProperty .
 :hasAnnotation rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf owl:topObjectProperty ;
                rdfs:domain :DataObjectEntity ;
-               rdfs:range :NameValuePair .
+               rdfs:range :NameValuePair ;
+               rdfs:comment "An annotation of the object. Annotations are values defined inside a dictionary that is accessible through an attribute of the object."@en ;
+               rdfs:label "has annotation"@en .
 
 
 ###  http://purl.org/alpaca#hasAttribute
 :hasAttribute rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf owl:topObjectProperty ;
               rdfs:domain :DataObjectEntity ;
-              rdfs:range :NameValuePair .
+              rdfs:range :NameValuePair ;
+              rdfs:comment "An attribute of the object. Attributes are direct properties of the object."@en ;
+              rdfs:label "has attribute"@en .
 
 
 ###  http://purl.org/alpaca#hasParameter
 :hasParameter rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf owl:topObjectProperty ;
               rdfs:domain :FunctionExecution ;
-              rdfs:range :NameValuePair .
+              rdfs:range :NameValuePair ;
+              rdfs:comment "A parameter for the execution of the function. A parameter is a value that is passed as an argument, that controls the behavior of the function, and that is not an input or an output."@en ;
+              rdfs:label "has parameter"@en .
 
 
 ###  http://purl.org/alpaca#usedFunction
 :usedFunction rdf:type owl:ObjectProperty ;
               rdfs:domain :FunctionExecution ;
-              rdfs:range :Function .
+              rdfs:range :Function ;
+              rdfs:comment "Function object used by the function execution."@en ;
+              rdfs:label "used function"@en .
 
 
 #################################################################
@@ -60,80 +68,106 @@ dcterms:creator rdf:type owl:AnnotationProperty .
 ###  http://purl.org/alpaca#codeStatement
 :codeStatement rdf:type owl:DatatypeProperty ;
                rdfs:domain :FunctionExecution ;
-               rdfs:range xsd:string .
+               rdfs:range xsd:string ;
+               rdfs:comment "The string of the code statement associated with the function execution."@en ;
+               rdfs:label "code statement"@en .
 
 
 ###  http://purl.org/alpaca#containerIndex
 :containerIndex rdf:type owl:DatatypeProperty ;
                 rdfs:domain :DataObjectEntity ;
-                rdfs:range rdfs:Literal .
+                rdfs:range rdfs:Literal ;
+                rdfs:comment "Value of the index to access the element in the container."@en ;
+                rdfs:label "container index"@en .
 
 
 ###  http://purl.org/alpaca#containerSlice
 :containerSlice rdf:type owl:DatatypeProperty ;
                 rdfs:domain :DataObjectEntity ;
-                rdfs:range rdfs:Literal .
+                rdfs:range rdfs:Literal ;
+                rdfs:comment "Slice (range of start to end index, with optional step size), whose values were used to access elements in the container."@en ;
+                rdfs:label "container slice"@en .
 
 
 ###  http://purl.org/alpaca#executionOrder
 :executionOrder rdf:type owl:DatatypeProperty ;
                 rdfs:domain :FunctionExecution ;
-                rdfs:range xsd:int .
+                rdfs:range xsd:int ;
+                rdfs:comment "Number identifying the order of function executions."@en ;
+                rdfs:label "execution order"@en .
 
 
 ###  http://purl.org/alpaca#filePath
 :filePath rdf:type owl:DatatypeProperty ;
           rdfs:domain :FileEntity ;
-          rdfs:range xsd:string .
+          rdfs:range xsd:string ;
+          rdfs:comment "Path to the file in the system where the code was run."@en ;
+          rdfs:label "file path"@en .
 
 
 ###  http://purl.org/alpaca#fromAttribute
 :fromAttribute rdf:type owl:DatatypeProperty ;
                rdfs:domain :DataObjectEntity ;
-               rdfs:range xsd:string .
+               rdfs:range xsd:string ;
+               rdfs:comment "Name of the attribute that was used to access the object."@en ;
+               rdfs:label "from attribute"@en .
 
 
 ###  http://purl.org/alpaca#functionName
 :functionName rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf owl:topDataProperty ;
               rdfs:domain :Function ;
-              rdfs:range xsd:string .
+              rdfs:range xsd:string ;
+              rdfs:comment "Name of the function as in its definition in the code."@en ;
+              rdfs:label "function name"@en .
 
 
 ###  http://purl.org/alpaca#functionVersion
 :functionVersion rdf:type owl:DatatypeProperty ;
                  rdfs:domain :Function ;
-                 rdfs:range xsd:string .
+                 rdfs:range xsd:string ;
+                 rdfs:comment "Version of the function."@en ;
+                 rdfs:label "function version"@en .
 
 
 ###  http://purl.org/alpaca#hashSource
 :hashSource rdf:type owl:DatatypeProperty ;
             rdfs:domain :DataObjectEntity ;
-            rdfs:range xsd:string .
+            rdfs:range xsd:string ;
+            rdfs:comment "Method used to compute a hash value."@en ;
+            rdfs:label "hash source"@en .
 
 
 ###  http://purl.org/alpaca#implementedIn
 :implementedIn rdf:type owl:DatatypeProperty ;
                rdfs:domain :Function ;
-               rdfs:range xsd:string .
+               rdfs:range xsd:string ;
+               rdfs:comment "Name of the package in which the function was implemented."@en ;
+               rdfs:label "implemented in"@en .
 
 
 ###  http://purl.org/alpaca#pairName
 :pairName rdf:type owl:DatatypeProperty ;
           rdfs:domain :NameValuePair ;
-          rdfs:range xsd:string .
+          rdfs:range xsd:string ;
+          rdfs:comment "Name used to identify the value."@en ;
+          rdfs:label "name"@en .
 
 
 ###  http://purl.org/alpaca#pairValue
 :pairValue rdf:type owl:DatatypeProperty ;
            rdfs:domain :NameValuePair ;
-           rdfs:range rdfs:Literal .
+           rdfs:range rdfs:Literal ;
+           rdfs:comment "Value associated with the name."@en ;
+           rdfs:label "value"@en .
 
 
 ###  http://purl.org/alpaca#scriptPath
 :scriptPath rdf:type owl:DatatypeProperty ;
             rdfs:domain :ScriptAgent ;
-            rdfs:range xsd:string .
+            rdfs:range xsd:string ;
+            rdfs:comment "Path to the file containing the script code in the system where it was run."@en ;
+            rdfs:label "script path"@en .
 
 
 #################################################################
@@ -143,34 +177,42 @@ dcterms:creator rdf:type owl:AnnotationProperty .
 ###  http://purl.org/alpaca#DataObjectEntity
 :DataObjectEntity rdf:type owl:Class ;
                   rdfs:subClassOf prov:Entity ;
-                  rdfs:comment "Represents an object that contains data." .
+                  owl:disjointWith :FileEntity ;
+                  rdfs:comment "Represents an object that contains data."@en ;
+                  rdfs:label "data object entity"@en .
 
 
 ###  http://purl.org/alpaca#FileEntity
 :FileEntity rdf:type owl:Class ;
             rdfs:subClassOf prov:Entity ;
-            rdfs:comment "Represents a file in the system." .
+            rdfs:comment "Represents a file in the system."@en ;
+            rdfs:label "file entity"@en .
 
 
 ###  http://purl.org/alpaca#Function
 :Function rdf:type owl:Class ;
-          rdfs:comment "Represents a function object. It contains code that is executed to perform some action in the script, taking parameters and producing outputs." .
+          rdfs:comment "Represents a function object. It contains code that is executed to perform some action in the script, taking parameters and producing outputs."@en ;
+          rdfs:label "function"@en .
 
 
 ###  http://purl.org/alpaca#FunctionExecution
 :FunctionExecution rdf:type owl:Class ;
                    rdfs:subClassOf prov:Activity ;
-                   rdfs:comment "The execution of a function with a set of inputs and parameters, that may produce one or more outputs." .
+                   rdfs:comment "The execution of a function with a set of inputs and parameters, that may produce one or more outputs."@en ;
+                   rdfs:label "function execution"@en .
 
 
 ###  http://purl.org/alpaca#NameValuePair
 :NameValuePair rdf:type owl:Class ;
-               rdfs:comment "Represents information defined by a name/value pair. Name is a string and value can be any literal value." .
+               rdfs:comment "Represents information defined by a name/value pair. Name is a string and value can be any literal value."@en ;
+               rdfs:label "name/value pair"@en .
 
 
 ###  http://purl.org/alpaca#ScriptAgent
 :ScriptAgent rdf:type owl:Class ;
-             rdfs:subClassOf prov:SoftwareAgent .
+             rdfs:subClassOf prov:SoftwareAgent ;
+             rdfs:comment "A file containing a set of instructions in Python that can be run to process data."@en ;
+             rdfs:label "script agent"@en .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/alpaca/ontology/alpaca.properties
+++ b/alpaca/ontology/alpaca.properties
@@ -1,5 +1,0 @@
-#Wed Nov 30 15:51:33 CET 2022
-jdbc.url=
-jdbc.driver=
-jdbc.user=
-jdbc.password=

--- a/alpaca/ontology/catalog-v001.xml
+++ b/alpaca/ontology/catalog-v001.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
-</catalog>

--- a/alpaca/test/res/class_method.ttl
+++ b/alpaca/test/res/class_method.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/collection.ttl
+++ b/alpaca/test/res/collection.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/file_input.ttl
+++ b/alpaca/test/res/file_input.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/file_output.ttl
+++ b/alpaca/test/res/file_output.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/input_container.ttl
+++ b/alpaca/test/res/input_container.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/input_multiple.ttl
+++ b/alpaca/test/res/input_multiple.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/input_output.ttl
+++ b/alpaca/test/res/input_output.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/metadata.ttl
+++ b/alpaca/test/res/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/multiple_memberships.ttl
+++ b/alpaca/test/res/multiple_memberships.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/none_output.ttl
+++ b/alpaca/test/res/none_output.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/alpaca/test/res/parallel_graph.ttl
+++ b/alpaca/test/res/parallel_graph.ttl
@@ -1,4 +1,4 @@
-@prefix alpaca: <https://github.com/INM-6/alpaca/ontology/alpaca.owl#> .
+@prefix alpaca: <http://purl.org/alpaca#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 


### PR DESCRIPTION
This PR introduces enhancements in the ontology definition:

* The base IRI was changed to a PURL that is mapped to the source OWL file;
* Added version and creator information;
* Added descriptions and labels for all classes and properties;
* Removed unnecessary files generated by Protégé.