### PR TITLE
[Fix] Update save_provenance function to avoid error when not capturing provenance

### DIFF
--- a/alpaca/decorator.py
+++ b/alpaca/decorator.py
@@ -598,10 +598,12 @@ class Provenance(object):
     @classmethod
     def clear(cls):
         """
-        Clears all the history and reset the execution counter to zero.
+        Clears all the history, resets the execution counter to zero,
+        and removes script information.
         """
         cls.history.clear()
         cls._call_count = 0
+        cls.script_info = None
 
 
 ##############################################################################

--- a/alpaca/decorator.py
+++ b/alpaca/decorator.py
@@ -675,6 +675,11 @@ def save_provenance(file_name=None, file_format='ttl'):
         If `file_name` is None, the function returns the PROV information as
         a string. If a file destination was informed, the return is None.
     """
+    # If provenance was not captured, there will be no information for the
+    # script. No information will be serialized.
+    if not Provenance.script_info:
+        return
+
     if file_format in RDF_FILE_FORMAT_MAP:
         file_format = RDF_FILE_FORMAT_MAP[file_format]
 

--- a/alpaca/test/test_decorator.py
+++ b/alpaca/test/test_decorator.py
@@ -171,6 +171,13 @@ class ProvenanceDecoratorInterfaceFunctionsTestCase(unittest.TestCase):
                 self.assertEqual(len(in_first), 0)
                 self.assertEqual(len(in_second), 0)
 
+    def test_save_provenance_no_capture(self):
+        Provenance.clear()
+        res = simple_function(TEST_ARRAY, 1, 2)
+
+        serialization = save_provenance(None, file_format='turtle')
+        self.assertIsNone(serialization)
+
     def test_print_history(self):
         activate(clear=True)
         res = simple_function(TEST_ARRAY, 1, 2)


### PR DESCRIPTION
If the `save_provenance` function is called when provenance capture was not activated, an exception will be generated, as no information describing the script will be present.

This PR modifies the function not to attempt to serialize the provenance information if the script information is unavailable. A unit test was added to check for this behavior.