### PR TITLE
[Fix] Function is not tracked if it is an attribute

### DIFF
--- a/alpaca/code_analysis/ast.py
+++ b/alpaca/code_analysis/ast.py
@@ -108,9 +108,19 @@ class _CallAST(ast.NodeVisitor):
 
     def visit_Call(self, node):
 
-        # Check if the Call is for the function being executed
-        if isinstance(node.func, ast.Name) and node.func.id == self.function:
+        func_name = self.function
 
+        # Check if the Call is for the function being executed.
+        # If a function is called using a namespace or as a method, the `func`
+        # attribute will be `ast.Attribute`.
+        function_in_execution = False
+        if isinstance(node.func, ast.Attribute):
+            attr_name = node.func.attr
+            function_in_execution = func_name.endswith(f".{attr_name}")
+        elif isinstance(node.func, ast.Name):
+            function_in_execution = node.func.id == func_name
+
+        if function_in_execution:
             # Fetch static information of Attribute and Subscript nodes that
             # were inputs. This should capture hierarchical information for
             # inputs that are class members or items in accessed in iterables


### PR DESCRIPTION
Currently, the tracking analysis will miss functions that are called as an attribute. 

For example, if `module.function` is instrumented with the `Provenance` decorator, the call

```
result = module.function(input)
```

will be missed.

This was an error in the analysis of the AST of the code statement.
This PR fixes that behavior, and implements unit tests.