### PR TITLE
[Enh] Use set for quick lookup of entity URIs present in the graph

### DIFF
--- a/alpaca/serialization/prov.py
+++ b/alpaca/serialization/prov.py
@@ -72,6 +72,10 @@ class AlpacaProvDocument(object):
             'neo': _neo_object_metadata
         }
 
+        # Set to store all entity URIs that are added to the graph, so that
+        # there is a fast lookup
+        self._entity_uris = set()
+
     # PROV relationships methods
 
     def _wasAttributedTo(self, entity, agent):
@@ -143,11 +147,12 @@ class AlpacaProvDocument(object):
         # If the entity already exists, skip it
         uri = URIRef(data_object_identifier(info, self._authority))
 
-        if uri in self.graph.subjects(RDF.type, ALPACA.DataObjectEntity):
+        if uri in self._entity_uris:
             return uri
         self.graph.add((uri, RDF.type, ALPACA.DataObjectEntity))
         self.graph.add((uri, ALPACA.hashSource, Literal(info.hash_method)))
         self._add_entity_metadata(uri, info)
+        self._entity_uris.add(uri)
         return uri
 
     def _add_FileEntity(self, info):


### PR DESCRIPTION
Currently, when building the RDF graph with the provenance information, the existence of a `DataObjectEntity` URI is checked with the `.subjects` method of the `rdflib` `Graph`, to avoid inserting duplicate entries. For large graphs, this is time-consuming.

With the changes in this PR, each new URI is stored in a set within the `ProvenanceGraph` object so that the lookup is faster.