### PR TITLE
[Fix] Error when getting the module version of a method descriptor

### DIFF
--- a/alpaca/decorator.py
+++ b/alpaca/decorator.py
@@ -257,9 +257,9 @@ class Provenance(object):
         return input_data, input_args_names, input_kwargs_names, default_args
 
     @staticmethod
-    def _get_module_version(module, function_name):
+    def _get_module_version(module):
 
-        if not module.startswith("__main__"):
+        if not module.startswith("__main__") or module is None:
             # User-defined functions in the running script do not have a
             # version
             package = module.split(".")[0]
@@ -332,10 +332,16 @@ class Provenance(object):
                 raise ValueError("Unknown assign target!")
 
         # 3. Extract function name and information
-        module = getattr(function, '__module__')
         function_name = function.__qualname__
-        module_version = self._get_module_version(module=module,
-                                                  function_name=function_name)
+        module = None
+        try:
+            module = getattr(function, '__module__')
+        except AttributeError:
+            # Case of method descriptors
+            if type(function).__qualname__ == "method_descriptor":
+                module = getattr(function.__objclass__, '__module__')
+
+        module_version = self._get_module_version(module)
         function_info = FunctionInfo(name=function_name, module=module,
                                      version=module_version)
 

--- a/alpaca/decorator.py
+++ b/alpaca/decorator.py
@@ -259,7 +259,7 @@ class Provenance(object):
     @staticmethod
     def _get_module_version(module):
 
-        if not module.startswith("__main__") or module is None:
+        if not (module is None or module.startswith("__main__")):
             # User-defined functions in the running script do not have a
             # version
             package = module.split(".")[0]

--- a/alpaca/test/test_decorator.py
+++ b/alpaca/test/test_decorator.py
@@ -232,19 +232,21 @@ class ProvenanceDecoratorFunctionsTestCase(unittest.TestCase):
     def test_get_module_version(self):
         expected_numpy_version = np.__version__
 
-        numpy_version = Provenance._get_module_version("numpy", "mean")
+        numpy_version = Provenance._get_module_version("numpy")
         self.assertEqual(numpy_version, expected_numpy_version)
 
         numpy_version_submodule = Provenance._get_module_version(
-            "numpy.random", "normal")
+            "numpy.random")
         self.assertEqual(numpy_version_submodule, expected_numpy_version)
 
-        main_version = Provenance._get_module_version("__main__",
-                                                      "test_function")
+        main_version = Provenance._get_module_version("__main__")
         self.assertEqual(main_version, "")
 
-        invalid = Provenance._get_module_version("non_existent", "test")
+        invalid = Provenance._get_module_version("non_existent")
         self.assertEqual(invalid, "")
+
+        none = Provenance._get_module_version(None)
+        self.assertEqual(none, "")
 
 
 class ProvenanceDecoratorInputOutputCombinationsTestCase(unittest.TestCase):


### PR DESCRIPTION
Some methods are implemented using the descriptor protocol, which will result in an exception when trying to fetch the version of the module of the class where it is implemented (the method object does not have a `__module__` attribute).

This PR fixes the error by identifying when it is a method descriptor and fetching the information from the correct place.