### PR TITLE
[Enh] Extended attribute selection for graph aggregation

### DIFF
--- a/alpaca/graph.py
+++ b/alpaca/graph.py
@@ -696,7 +696,7 @@ class ProvenanceGraph:
                     # We have requested grouping for this object based on
                     # selected attributes. Otherwise, we will use the label
                     for attr in data_attributes:
-                        group_info.append(data[attr])
+                        group_info.append(data.get(attr, None))
             return tuple(group_info)
 
         # We don't consider edges

--- a/alpaca/graph.py
+++ b/alpaca/graph.py
@@ -611,13 +611,26 @@ class ProvenanceGraph:
         group_node_attributes : dict
             Dictionary selecting which attributes are used in the aggregation.
             The keys are the possible labels in the graph, and the values
-            are tuples of the node attributes used for determining supernodes.
+            are tuples of the node attributes or callables used for
+            determining supernodes.
+
             For example, to aggregate `Quantity` nodes based on different
             `shape` attribute values, `group_node_attributes` would be
             `{'Quantity': ('shape',)}`. If passing an empty dictionary, no
             attributes will be considered, and the aggregation will be based
             on the topology (i.e., nodes at similar levels will be grouped
             according to the connectivity).
+
+            In addition to attribute names, callables that take the
+            arguments `(graph, node, data)`, where `graph` is the graph being
+            aggregated, `node` is the node being evaluated for grouping, and
+            `data` is the dictionary of attributes, can be used. The returned
+            value is used to define the group. This allows flexibility when
+            grouping, as attribute values can be transformed (e.g., extracting
+            a token such as file extension from an attribute that stores the
+            path as a string), or the relationship of the node to neighbors
+            and values of edges can be checked. However, this will increase
+            the time to evaluate the grouping criteria of a node.
         use_function_parameters : bool, optional
             If True, the parameters of function nodes in the graph will be
             considered in the aggregation, i.e., if the same function is called
@@ -661,8 +674,8 @@ class ProvenanceGraph:
         [1]_.
 
         The function was modified to group the nodes based on different
-        attributes  (using a dictionary based on the labels) instead of a
-        single attribute that is common to all nodes.
+        attributes or callables (using a dictionary based on the labels)
+        instead of attributes that are common to all nodes.
 
         During the summary graph generation, the attribute values are also
         summarized, so that the user has an idea of all the possible values in
@@ -679,7 +692,7 @@ class ProvenanceGraph:
            June 2008.
         """
 
-        def _fetch_group_tuple(data, label, data_attributes,
+        def _fetch_group_tuple(graph, node, data, label, data_attributes,
                                use_function_params):
             group_info = [label]
 
@@ -694,9 +707,24 @@ class ProvenanceGraph:
             else:
                 if data_attributes is not None:
                     # We have requested grouping for this object based on
-                    # selected attributes. Otherwise, we will use the label
+                    # selected attributes/callables. Otherwise, we will use
+                    # the label only
+
                     for attr in data_attributes:
-                        group_info.append(data.get(attr, None))
+
+                        if callable(attr):
+                            # We have requested grouping using a function that
+                            # takes the graph, the node, and the node
+                            # attributes as parameters. This allows a more
+                            # customized filtering, that can extract specific
+                            # information from the attribute value or use the
+                            # node relationships
+                            group_info.append(attr(graph, node, data))
+                        else:
+                            # Fetch the attribute value for this node, if
+                            # available
+                            group_info.append(data.get(attr, None))
+
             return tuple(group_info)
 
         # We don't consider edges
@@ -704,7 +732,8 @@ class ProvenanceGraph:
 
         # Create the groups based on the selected conditions
         group_lookup = {
-            node: _fetch_group_tuple(attrs, attrs['label'],
+            node: _fetch_group_tuple(
+                self.graph, node, attrs, attrs['label'],
                 group_node_attributes.get(attrs['label'], None),
                 use_function_parameters)
             for node, attrs in self.graph.nodes.items()

--- a/alpaca/test/res/multiple_file_output.ttl
+++ b/alpaca/test/res/multiple_file_output.ttl
@@ -1,0 +1,103 @@
+@prefix alpaca: <http://purl.org/alpaca#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:my-authority:alpaca:file:sha256:98765> a alpaca:FileEntity ;
+    alpaca:filePath "/outputs/1.png"^^xsd:string ;
+    prov:wasDerivedFrom <urn:my-authority:alpaca:object:Python:test.InputObject:12345> ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    prov:wasGeneratedBy <urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#12345> .
+
+<urn:my-authority:alpaca:file:sha256:987651> a alpaca:FileEntity ;
+    alpaca:filePath "/outputs/2.png"^^xsd:string ;
+    prov:wasDerivedFrom <urn:my-authority:alpaca:object:Python:test.InputObject:123452> ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    prov:wasGeneratedBy <urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#123452> .
+
+<urn:my-authority:alpaca:object:Python:builtins.NoneType:777777> a alpaca:DataObjectEntity ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999>  ;
+    prov:wasDerivedFrom <urn:my-authority:alpaca:object:Python:test.InputObject:12345> ;
+    prov:wasGeneratedBy <urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#12345> ;
+    alpaca:hashSource "UUID" .
+
+<urn:my-authority:alpaca:object:Python:builtins.NoneType:7777772> a alpaca:DataObjectEntity ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999>  ;
+    prov:wasDerivedFrom <urn:my-authority:alpaca:object:Python:test.InputObject:123452> ;
+    prov:wasGeneratedBy <urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#123452> ;
+    alpaca:hashSource "UUID" .
+
+<urn:my-authority:alpaca:object:Python:test.InputObject:12345> a alpaca:DataObjectEntity ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    prov:wasDerivedFrom <urn:my-authority:alpaca:object:Python:test.InputObject:22345> ;
+    prov:wasGeneratedBy <urn:my-authority:alpaca:function_execution:Python:111111:999999:test.cut_function#12345> ;
+    alpaca:hashSource "joblib_SHA1" .
+
+<urn:my-authority:alpaca:object:Python:test.InputObject:123452> a alpaca:DataObjectEntity ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    prov:wasDerivedFrom <urn:my-authority:alpaca:object:Python:test.InputObject:22345> ;
+    prov:wasGeneratedBy <urn:my-authority:alpaca:function_execution:Python:111111:999999:test.cut_function#12345> ;
+    alpaca:hashSource "joblib_SHA1" .
+
+<urn:my-authority:alpaca:object:Python:test.InputObject:22345> a alpaca:DataObjectEntity ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    alpaca:hashSource "joblib_SHA1" .
+
+<urn:my-authority:alpaca:file:sha256:18765> a alpaca:FileEntity ;
+    alpaca:filePath "/full.png"^^xsd:string ;
+    prov:wasDerivedFrom <urn:my-authority:alpaca:object:Python:test.InputObject:22345> ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    prov:wasGeneratedBy <urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#22345> .
+
+<urn:my-authority:alpaca:object:Python:builtins.NoneType:666666> a alpaca:DataObjectEntity ;
+    prov:wasAttributedTo <urn:my-authority:alpaca:script:Python:script.py:111111#999999>  ;
+    prov:wasDerivedFrom <urn:my-authority:alpaca:object:Python:test.InputObject:22345> ;
+    prov:wasGeneratedBy <urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#22345> ;
+    alpaca:hashSource "UUID" .
+
+<urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#12345> a alpaca:FunctionExecution ;
+    prov:startedAtTime "2022-05-02T12:34:56.123456"^^xsd:dateTime ;
+    prov:endedAtTime "2022-05-02T12:35:56.123456"^^xsd:dateTime ;
+    prov:used <urn:my-authority:alpaca:object:Python:test.InputObject:12345> ;
+    prov:wasAssociatedWith <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    alpaca:codeStatement "plot_function(input, out_file)" ;
+    alpaca:executionOrder 3 ;
+    alpaca:usedFunction <urn:my-authority:alpaca:function:Python:test.plot_function> .
+
+<urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#123452> a alpaca:FunctionExecution ;
+    prov:startedAtTime "2022-05-02T12:34:56.123456"^^xsd:dateTime ;
+    prov:endedAtTime "2022-05-02T12:35:56.123456"^^xsd:dateTime ;
+    prov:used <urn:my-authority:alpaca:object:Python:test.InputObject:123452> ;
+    prov:wasAssociatedWith <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    alpaca:codeStatement "plot_function(input, out_file)" ;
+    alpaca:executionOrder 4 ;
+    alpaca:usedFunction <urn:my-authority:alpaca:function:Python:test.plot_function> .
+
+<urn:my-authority:alpaca:function_execution:Python:111111:999999:test.plot_function#22345> a alpaca:FunctionExecution ;
+    prov:startedAtTime "2022-05-02T12:34:56.123456"^^xsd:dateTime ;
+    prov:endedAtTime "2022-05-02T12:35:56.123456"^^xsd:dateTime ;
+    prov:used <urn:my-authority:alpaca:object:Python:test.InputObject:22345> ;
+    prov:wasAssociatedWith <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    alpaca:codeStatement "plot_function(input, out_file)" ;
+    alpaca:executionOrder 1 ;
+    alpaca:usedFunction <urn:my-authority:alpaca:function:Python:test.plot_function> .
+
+<urn:my-authority:alpaca:function_execution:Python:111111:999999:test.cut_function#12345> a alpaca:FunctionExecution ;prov:startedAtTime "2022-05-02T12:34:56.123456"^^xsd:dateTime ;
+    prov:endedAtTime "2022-05-02T12:35:56.123456"^^xsd:dateTime ;
+    prov:used <urn:my-authority:alpaca:object:Python:test.InputObject:22345> ;
+    prov:wasAssociatedWith <urn:my-authority:alpaca:script:Python:script.py:111111#999999> ;
+    alpaca:codeStatement "cut_function(full_data)" ;
+    alpaca:executionOrder 2 ;
+    alpaca:usedFunction <urn:my-authority:alpaca:function:Python:test.cut_function> .
+                                                                                           
+<urn:my-authority:alpaca:function:Python:test.plot_function> a alpaca:Function ;
+    alpaca:functionName "plot_function" ;
+    alpaca:implementedIn "test" ;
+    alpaca:functionVersion "0.0.1" .
+
+<urn:my-authority:alpaca:function:Python:test.cut_function> a alpaca:Function ;
+    alpaca:functionName "cut_function" ;
+    alpaca:implementedIn "test" ;
+    alpaca:functionVersion "0.0.1" .
+
+<urn:my-authority:alpaca:script:Python:script.py:111111#999999> a alpaca:ScriptAgent ;
+    alpaca:scriptPath "/script.py" .

--- a/alpaca/test/res/parallel_graph.ttl
+++ b/alpaca/test/res/parallel_graph.ttl
@@ -136,7 +136,10 @@
             alpaca:pairValue 5 ],
         [ a alpaca:NameValuePair ;
             alpaca:pairName "shape" ;
-            alpaca:pairValue "(2,)" ] ;
+            alpaca:pairValue "(2,)" ],
+        [ a alpaca:NameValuePair ;
+            alpaca:pairName "id" ;
+            alpaca:pairValue 1 ] ;
     alpaca:hashSource "joblib_SHA1" .
 
 <urn:fz-juelich.de:alpaca:object:Python:__main__.InputObject:eed23509f67bfc5dd108fe361ce57a1b9737a286> a alpaca:DataObjectEntity ;


### PR DESCRIPTION
This PR adds two features to the existing provenance graph aggregations:

1. Previously, for nodes with a given label, it was not possible to use an attribute that was not present in all nodes (an exception was raised). It is now possible to specify attributes that are not shared among all nodes. If that attribute is not present, it will be assumed as None when evaluating the grouping.

2. In addition to strings with node attribute names, it is possible to pass callables that take the form `callable(graph, node, data)`. The callable can then access the NetworkX graph object, the node id, and the full node attributes dictionary. With this enhancement, it is possible to consider transformations of attribute values or the relationships of nodes in the graph when grouping.

For example, if trying to group files (label `File`) using the `File_path` attribute captured by Alpaca, a supernode in the aggregation would be created for every different file path when using the attribute name:

```
aggregated = graph.aggregate({'File': ('File_path',)})
```

With a callable, it is possible to find other similarities to group the nodes, such as the start of the path string in `File_path`:

```
is_output_file = lambda graph, node, data: data['File_path'].startswith("/outputs/")
aggregated = graph.aggregate({'File': (is_output_file,)})
``` 