### PR TITLE
Use value to check for duplicate metadata property in the visualization graph

### DIFF
--- a/alpaca/graph.py
+++ b/alpaca/graph.py
@@ -84,7 +84,7 @@ def _add_attribute(data, attr_name, attr_type, attr_value, strip_namespace):
     if not strip_namespace:
         attr_name = f"{ATTR_NAMES[attr_type]}:{attr_name}"
 
-    if attr_name in data:
+    if attr_name in data and data[attr_name] != attr_value:
         raise ValueError(
             "Duplicate property values. Make sure to include the namespaces!")
     data[attr_name] = attr_value


### PR DESCRIPTION
When building visualization graphs (with NetworkX), there is a check to avoid inserting ambiguous metadata in the nodes (if different objects exist with the same identifiers). However, when merging multiple graphs for visualization, the RDF description of the same data object may exist in both RDF files. Therefore, the graph visualization would fail because the check did not consider the attribute's value. This fixes the behavior by throwing an exception only when inserting the same attribute with different values in an existing node where that metadata attribute is already defined.