### PR TITLE
Fixed error when removing None nodes in the visualization and a None was an input to a function

### DIFF
--- a/alpaca/graph.py
+++ b/alpaca/graph.py
@@ -411,10 +411,12 @@ class ProvenanceGraph:
             # Add all the edges from sources to activity and from activity
             # to targets
             for source in source_entities:
-                transformed.add_edge(source, node_id, membership=False)
-                if time_intervals:
-                    _add_gephi_interval(transformed.nodes[source],
-                                    node_data['execution_order'])
+                if not remove_none or (
+                        remove_none and source not in none_nodes):
+                    transformed.add_edge(source, node_id, membership=False)
+                    if time_intervals:
+                        _add_gephi_interval(transformed.nodes[source],
+                                        node_data['execution_order'])
 
             if not remove_none or (remove_none and target not in none_nodes):
                 transformed.add_edge(node_id, target, membership=False)


### PR DESCRIPTION
When using the option to remove None nodes in the graph visualization to declutter the graph, an error was thrown in case None nodes were at the input. The initial implementation considered only None nodes as outputs. This PR fixes this behavior, to also allow pruning of the None nodes as function inputs.